### PR TITLE
Finalize 0.1.0 Proposal

### DIFF
--- a/lib/sheriff/plug/enforce_policy.ex
+++ b/lib/sheriff/plug/enforce_policy.ex
@@ -7,6 +7,7 @@ defmodule Sheriff.Plug.EnforcePolicy do
   alias Sheriff.Plug
 
   @not_permitted "you are not permitted to perform the requested action"
+  @resource_key Application.get_env(:sheriff, :resource_key, :current_user)
 
   @doc false
   def init(opts), do: opts
@@ -25,7 +26,7 @@ defmodule Sheriff.Plug.EnforcePolicy do
   end
 
   defp fetch_actor(conn) do
-    {conn.private[:current_user], conn}
+    {conn.private[@resource_key], conn}
   end
 
   defp fetch_resource({nil, conn}, opts), do: handle_error(:unauthenticated, conn, opts)


### PR DESCRIPTION
The last change in the API made was to get up Sheriff to not force the use of `:current_user` as the resource's key name in the `Plug.Conn.private` map. After discussing today I think we are good with this, and I am finalizing the example application now.